### PR TITLE
Fix custom configurator cart add issue

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -15,22 +15,31 @@ use Magento\Framework\Filesystem\Driver\File;
 use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Backend\Controller\Adminhtml\Cache\MassRefresh;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Module\Manager as ModuleManager;
+use Psr\Log\LoggerInterface;
 
 class Data extends AbstractHelper
 {
     public const GQL_FILE_NAME = 'gql.php';
+    public const CONFIGURATOR_MODULE_NAME = 'HappyHorizon_ConfiguratorGraphQl';
+    
     /**
      * @param Context $context
      * @param DirectoryList $dir
      * @param File $file
      * @param MassRefresh $massRefresh
+     * @param Json $json
+     * @param ModuleManager $moduleManager
+     * @param LoggerInterface $logger
      */
     public function __construct(
         protected Context $context,
         protected DirectoryList $dir,
         protected File $file,
         protected MassRefresh $massRefresh,
-        protected Json $json
+        protected Json $json,
+        protected ModuleManager $moduleManager,
+        protected LoggerInterface $logger
     ) {
         parent::__construct($context);
     }
@@ -97,17 +106,18 @@ class Data extends AbstractHelper
 
     /**
      * @param $path
-     * @return string|void
+     * @return string
      */
-    public function getFileContent($path)
+    public function getFileContent($path): string
     {
         try {
             if ($this->checkIfFileExists($path)) {
-                $this->file->fileGetContents($path);
+                return $this->file->fileGetContents($path);
             }
         } catch (FileSystemException $e) {
             return "";
         }
+        return "";
     }
 
     /**
@@ -126,5 +136,73 @@ class Data extends AbstractHelper
     public function decodeData($data): mixed
     {
         return $this->json->unserialize($data);
+    }
+
+    /**
+     * Check if ConfiguratorGraphQl module is enabled
+     *
+     * @return bool
+     */
+    public function isConfiguratorModuleEnabled(): bool
+    {
+        return $this->moduleManager->isEnabled(self::CONFIGURATOR_MODULE_NAME);
+    }
+
+    /**
+     * Validate if cached schema includes configurator extensions
+     *
+     * @param array $schema
+     * @return bool
+     */
+    public function validateSchemaIncludesConfigurator(array $schema): bool
+    {
+        // If configurator module is not enabled, schema is valid
+        if (!$this->isConfiguratorModuleEnabled()) {
+            return true;
+        }
+
+        // Check if CartItemInput type exists and includes configurator_options field
+        // Schema structure can vary, so check multiple possible locations
+        $cartItemInputFound = false;
+        $configuratorOptionsFound = false;
+
+        // Check direct access
+        if (isset($schema['CartItemInput'])) {
+            $cartItemInputFound = true;
+            if (isset($schema['CartItemInput']['fields']['configurator_options'])) {
+                $configuratorOptionsFound = true;
+            }
+        }
+
+        // Also check if schema is nested differently (some Magento versions)
+        if (!$cartItemInputFound) {
+            foreach ($schema as $key => $value) {
+                if (is_array($value) && isset($value['name']) && $value['name'] === 'CartItemInput') {
+                    $cartItemInputFound = true;
+                    if (isset($value['fields']['configurator_options'])) {
+                        $configuratorOptionsFound = true;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if ($cartItemInputFound && $configuratorOptionsFound) {
+            return true;
+        }
+
+        // Schema is missing configurator extensions
+        if ($cartItemInputFound) {
+            $this->logger->warning(
+                'PersistentGraphQlSchema: Cached schema is missing configurator_options field in CartItemInput. ' .
+                'Schema will be regenerated.'
+            );
+        } else {
+            $this->logger->warning(
+                'PersistentGraphQlSchema: Cached schema structure unexpected (CartItemInput not found). ' .
+                'Schema will be regenerated.'
+            );
+        }
+        return false;
     }
 }

--- a/Plugin/Graphql/Magento/Framework/GraphQlSchemaStitching/Common/Reader.php
+++ b/Plugin/Graphql/Magento/Framework/GraphQlSchemaStitching/Common/Reader.php
@@ -9,16 +9,19 @@ namespace HappyHorizon\PersistentGraphQlSchema\Plugin\Graphql\Magento\Framework\
 
 use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
 use Magento\Framework\Filesystem\DirectoryList;
+use Psr\Log\LoggerInterface;
 
 class Reader
 {
     /**
      * @param DirectoryList $dir
      * @param Data $helper
+     * @param LoggerInterface $logger
      */
     public function __construct(
         protected DirectoryList $dir,
-        protected Data $helper
+        protected Data $helper,
+        protected LoggerInterface $logger
     ) {
     }
 
@@ -38,15 +41,65 @@ class Reader
         try {
             $data = $this->helper->checkIfFileExists($filename)? $this->helper->getFileContent($filename): false;
         } catch (\Exception $e) {
+            $this->logger->error(
+                'PersistentGraphQlSchema: Error reading cached schema file: ' . $e->getMessage(),
+                ['exception' => $e, 'filename' => $filename]
+            );
             $data = false;
         }
 
         if (false === $data || '' === (string)$data) {
-            $data = $proceed();
-            $this->helper->saveFileContent($filename, $this->helper->encodeData($data));
-            return $data;
+            // No cached schema exists, generate and save it
+            try {
+                $data = $proceed();
+                $this->helper->saveFileContent($filename, $this->helper->encodeData($data));
+                $this->logger->info('PersistentGraphQlSchema: Generated and cached new GraphQL schema');
+                return $data;
+            } catch (\Exception $e) {
+                $this->logger->error(
+                    'PersistentGraphQlSchema: Error generating schema: ' . $e->getMessage(),
+                    ['exception' => $e]
+                );
+                // Fallback to original behavior if caching fails
+                return $proceed();
+            }
         } else {
-            return $this->helper->decodeData($data);
+            // Decode cached schema
+            try {
+                $decodedData = $this->helper->decodeData($data);
+                
+                if (!is_array($decodedData)) {
+                    $this->logger->warning(
+                        'PersistentGraphQlSchema: Cached schema data is invalid, regenerating'
+                    );
+                    $this->helper->removeFile($filename);
+                    $data = $proceed();
+                    $this->helper->saveFileContent($filename, $this->helper->encodeData($data));
+                    return $data;
+                }
+                
+                // Validate that cached schema includes required extensions (e.g., configurator_options)
+                if (!$this->helper->validateSchemaIncludesConfigurator($decodedData)) {
+                    // Schema is stale, regenerate it
+                    $this->logger->info(
+                        'PersistentGraphQlSchema: Cached schema is stale, regenerating with latest extensions'
+                    );
+                    $this->helper->removeFile($filename);
+                    $data = $proceed();
+                    $this->helper->saveFileContent($filename, $this->helper->encodeData($data));
+                    return $data;
+                }
+                
+                return $decodedData;
+            } catch (\Exception $e) {
+                $this->logger->error(
+                    'PersistentGraphQlSchema: Error decoding cached schema: ' . $e->getMessage(),
+                    ['exception' => $e]
+                );
+                // Fallback to regenerating schema
+                $this->helper->removeFile($filename);
+                return $proceed();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes custom product cart issues by ensuring GraphQL schema regenerates when stale or missing configurator options.

The `getFileContent` method in `Helper/Data.php` was not returning the file content, causing the cached GraphQL schema to be effectively empty or invalid. This prevented the `HappyHorizon_ConfiguratorGraphQl` module's extensions (like `configurator_options` in `CartItemInput`) from being included in the active schema, leading to custom products failing to add to the cart. The changes also add explicit validation for the presence of `configurator_options` and trigger schema regeneration if they are missing or the schema is otherwise invalid.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fd0b1e7-7aa1-4d8b-b83f-b49ca7cab721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3fd0b1e7-7aa1-4d8b-b83f-b49ca7cab721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

