### PR TITLE
Implement and validate href lang and canonical URLs

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -15,6 +15,9 @@ use Magento\Framework\Filesystem\Driver\File;
 use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Backend\Controller\Adminhtml\Cache\MassRefresh;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\Store;
 
 class Data extends AbstractHelper
 {
@@ -24,13 +27,18 @@ class Data extends AbstractHelper
      * @param DirectoryList $dir
      * @param File $file
      * @param MassRefresh $massRefresh
+     * @param Json $json
+     * @param StoreManagerInterface $storeManager
+     * @param UrlInterface $urlBuilder
      */
     public function __construct(
         protected Context $context,
         protected DirectoryList $dir,
         protected File $file,
         protected MassRefresh $massRefresh,
-        protected Json $json
+        protected Json $json,
+        protected StoreManagerInterface $storeManager,
+        protected UrlInterface $urlBuilder
     ) {
         parent::__construct($context);
     }
@@ -97,17 +105,18 @@ class Data extends AbstractHelper
 
     /**
      * @param $path
-     * @return string|void
+     * @return string
      */
-    public function getFileContent($path)
+    public function getFileContent($path): string
     {
         try {
             if ($this->checkIfFileExists($path)) {
-                $this->file->fileGetContents($path);
+                return $this->file->fileGetContents($path);
             }
         } catch (FileSystemException $e) {
             return "";
         }
+        return "";
     }
 
     /**
@@ -126,5 +135,139 @@ class Data extends AbstractHelper
     public function decodeData($data): mixed
     {
         return $this->json->unserialize($data);
+    }
+
+    /**
+     * Get alternate URLs for hreflang tags
+     *
+     * @param string $urlPath The URL path (e.g., product URL key, category URL key, CMS page identifier)
+     * @param string|null $entityType Type of entity: 'product', 'category', or 'cms_page'
+     * @return array Array of alternate URLs with hreflang structure: [['hreflang' => 'en', 'href' => 'url'], ...]
+     */
+    public function getAlternateUrls(string $urlPath, ?string $entityType = null): array
+    {
+        $alternateUrls = [];
+        
+        try {
+            $currentStore = $this->storeManager->getStore();
+            $stores = $this->storeManager->getStores();
+            
+            foreach ($stores as $store) {
+                if (!$store->getIsActive()) {
+                    continue;
+                }
+                
+                $storeCode = $store->getCode();
+                $localeCode = $this->getLocaleCode($store);
+                
+                try {
+                    $storeUrl = $this->buildEntityUrl($store, $urlPath, $entityType);
+                    
+                    if ($storeUrl) {
+                        $alternateUrls[] = [
+                            'hreflang' => $localeCode,
+                            'href' => $storeUrl
+                        ];
+                    }
+                } catch (\Exception $e) {
+                    $this->context->getLogger()->error(
+                        sprintf('Error generating alternate URL for store %s: %s', $storeCode, $e->getMessage())
+                    );
+                }
+            }
+        } catch (\Exception $e) {
+            $this->context->getLogger()->error(
+                sprintf('Error generating alternate URLs: %s', $e->getMessage())
+            );
+        }
+        
+        return $alternateUrls;
+    }
+
+    /**
+     * Get canonical URL for the current store
+     *
+     * @param string $urlPath The URL path (e.g., product URL key, category URL key, CMS page identifier)
+     * @param string|null $entityType Type of entity: 'product', 'category', or 'cms_page'
+     * @return string|null Canonical URL or null if unable to generate
+     */
+    public function getCanonicalUrl(string $urlPath, ?string $entityType = null): ?string
+    {
+        try {
+            $currentStore = $this->storeManager->getStore();
+            return $this->buildEntityUrl($currentStore, $urlPath, $entityType);
+        } catch (\Exception $e) {
+            $this->context->getLogger()->error(
+                sprintf('Error generating canonical URL: %s', $e->getMessage())
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Build URL for a specific entity type and store
+     *
+     * @param Store $store
+     * @param string $urlPath
+     * @param string|null $entityType
+     * @return string|null
+     */
+    protected function buildEntityUrl(Store $store, string $urlPath, ?string $entityType): ?string
+    {
+        try {
+            $baseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_LINK);
+            $baseUrl = rtrim($baseUrl, '/');
+            
+            // Remove query parameters and fragments from URL path
+            $urlPath = preg_replace('/[?#].*$/', '', $urlPath);
+            $urlPath = ltrim($urlPath, '/');
+            
+            // Normalize URL path based on entity type
+            if ($entityType === 'cms_page') {
+                // CMS pages typically don't need a prefix, but ensure proper format
+                if (!empty($urlPath)) {
+                    $urlPath = ltrim($urlPath, '/');
+                }
+            } elseif ($entityType === 'category') {
+                // Categories may have path structure
+                if (!empty($urlPath)) {
+                    $urlPath = ltrim($urlPath, '/');
+                }
+            } elseif ($entityType === 'product') {
+                // Products typically have .html suffix, but it should already be in urlPath
+                if (!empty($urlPath)) {
+                    $urlPath = ltrim($urlPath, '/');
+                }
+            }
+            
+            // Build full URL
+            $fullUrl = $baseUrl . '/' . $urlPath;
+            
+            // Ensure proper URL format
+            return filter_var($fullUrl, FILTER_VALIDATE_URL) ? $fullUrl : null;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Get locale code for a store (e.g., 'en-US', 'nl-NL')
+     *
+     * @param Store $store
+     * @return string
+     */
+    protected function getLocaleCode(Store $store): string
+    {
+        try {
+            $locale = $store->getConfig(\Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE);
+            if ($locale) {
+                return str_replace('_', '-', $locale);
+            }
+        } catch (\Exception $e) {
+            // Fallback to store code if locale config is not available
+        }
+        
+        // Fallback: use store code or default to 'en'
+        return $store->getCode() ?: 'en';
     }
 }

--- a/Model/Resolver/Category/AlternateUrls.php
+++ b/Model/Resolver/Category/AlternateUrls.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver\Category;
+
+use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Model\Category;
+
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @param Data $helper
+     */
+    public function __construct(
+        protected Data $helper
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            return [];
+        }
+
+        /** @var Category $category */
+        $category = $value['model'];
+        
+        if (!$category instanceof CategoryInterface) {
+            return [];
+        }
+
+        try {
+            $urlKey = $category->getUrlKey();
+            if (!$urlKey) {
+                return [];
+            }
+
+            // Build category URL path
+            $urlPath = $category->getUrlPath() ?: $category->getUrlKey();
+            
+            return $this->helper->getAlternateUrls($urlPath, 'category');
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
+}

--- a/Model/Resolver/Category/CanonicalUrl.php
+++ b/Model/Resolver/Category/CanonicalUrl.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver\Category;
+
+use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Model\Category;
+
+class CanonicalUrl implements ResolverInterface
+{
+    /**
+     * @param Data $helper
+     */
+    public function __construct(
+        protected Data $helper
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            return null;
+        }
+
+        /** @var Category $category */
+        $category = $value['model'];
+        
+        if (!$category instanceof CategoryInterface) {
+            return null;
+        }
+
+        try {
+            $urlKey = $category->getUrlKey();
+            if (!$urlKey) {
+                return null;
+            }
+
+            // Build category URL path
+            $urlPath = $category->getUrlPath() ?: $category->getUrlKey();
+            
+            return $this->helper->getCanonicalUrl($urlPath, 'category');
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/Model/Resolver/CmsPage/AlternateUrls.php
+++ b/Model/Resolver/CmsPage/AlternateUrls.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver\CmsPage;
+
+use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Cms\Model\Page;
+
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @param Data $helper
+     */
+    public function __construct(
+        protected Data $helper
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            return [];
+        }
+
+        /** @var Page $page */
+        $page = $value['model'];
+        
+        if (!$page instanceof PageInterface) {
+            return [];
+        }
+
+        try {
+            $identifier = $page->getIdentifier();
+            if (!$identifier) {
+                return [];
+            }
+
+            // Build CMS page URL path
+            $urlPath = $identifier;
+            
+            return $this->helper->getAlternateUrls($urlPath, 'cms_page');
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
+}

--- a/Model/Resolver/CmsPage/CanonicalUrl.php
+++ b/Model/Resolver/CmsPage/CanonicalUrl.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver\CmsPage;
+
+use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Cms\Model\Page;
+
+class CanonicalUrl implements ResolverInterface
+{
+    /**
+     * @param Data $helper
+     */
+    public function __construct(
+        protected Data $helper
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            return null;
+        }
+
+        /** @var Page $page */
+        $page = $value['model'];
+        
+        if (!$page instanceof PageInterface) {
+            return null;
+        }
+
+        try {
+            $identifier = $page->getIdentifier();
+            if (!$identifier) {
+                return null;
+            }
+
+            // Build CMS page URL path
+            $urlPath = $identifier;
+            
+            return $this->helper->getCanonicalUrl($urlPath, 'cms_page');
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/Model/Resolver/Product/AlternateUrls.php
+++ b/Model/Resolver/Product/AlternateUrls.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver\Product;
+
+use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Store\Model\StoreManagerInterface;
+
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @param Data $helper
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        protected Data $helper,
+        protected StoreManagerInterface $storeManager
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            return [];
+        }
+
+        /** @var Product $product */
+        $product = $value['model'];
+        
+        if (!$product instanceof ProductInterface) {
+            return [];
+        }
+
+        try {
+            $urlKey = $product->getUrlKey();
+            if (!$urlKey) {
+                return [];
+            }
+
+            // Build product URL path
+            $urlPath = $product->getUrlKey() . $product->getUrlSuffix();
+            
+            return $this->helper->getAlternateUrls($urlPath, 'product');
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
+}

--- a/Model/Resolver/Product/CanonicalUrl.php
+++ b/Model/Resolver/Product/CanonicalUrl.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver\Product;
+
+use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
+
+class CanonicalUrl implements ResolverInterface
+{
+    /**
+     * @param Data $helper
+     */
+    public function __construct(
+        protected Data $helper
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            return null;
+        }
+
+        /** @var Product $product */
+        $product = $value['model'];
+        
+        if (!$product instanceof ProductInterface) {
+            return null;
+        }
+
+        try {
+            $urlKey = $product->getUrlKey();
+            if (!$urlKey) {
+                return null;
+            }
+
+            // Build product URL path
+            $urlPath = $product->getUrlKey() . $product->getUrlSuffix();
+            
+            return $this->helper->getCanonicalUrl($urlPath, 'product');
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/Plugin/Graphql/Magento/Framework/GraphQlSchemaStitching/Common/Reader.php
+++ b/Plugin/Graphql/Magento/Framework/GraphQlSchemaStitching/Common/Reader.php
@@ -9,16 +9,19 @@ namespace HappyHorizon\PersistentGraphQlSchema\Plugin\Graphql\Magento\Framework\
 
 use HappyHorizon\PersistentGraphQlSchema\Helper\Data;
 use Magento\Framework\Filesystem\DirectoryList;
+use Psr\Log\LoggerInterface;
 
 class Reader
 {
     /**
      * @param DirectoryList $dir
      * @param Data $helper
+     * @param LoggerInterface $logger
      */
     public function __construct(
         protected DirectoryList $dir,
-        protected Data $helper
+        protected Data $helper,
+        protected LoggerInterface $logger
     ) {
     }
 
@@ -35,18 +38,117 @@ class Reader
     ): array {
         $filename = $this->helper->getGqlPath();
 
+        $this->logger->info('GraphQL Schema Reader: Starting schema read operation', [
+            'scope' => $scope,
+            'filename' => $filename
+        ]);
+
         try {
-            $data = $this->helper->checkIfFileExists($filename)? $this->helper->getFileContent($filename): false;
+            $data = $this->helper->checkIfFileExists($filename) ? $this->helper->getFileContent($filename) : false;
         } catch (\Exception $e) {
+            $this->logger->warning('GraphQL Schema Reader: Error checking file existence', [
+                'filename' => $filename,
+                'error' => $e->getMessage()
+            ]);
             $data = false;
         }
 
         if (false === $data || '' === (string)$data) {
+            $this->logger->info('GraphQL Schema Reader: Schema file not found, generating new schema');
             $data = $proceed();
             $this->helper->saveFileContent($filename, $this->helper->encodeData($data));
+            $this->logger->info('GraphQL Schema Reader: New schema generated and saved');
             return $data;
         } else {
-            return $this->helper->decodeData($data);
+            try {
+                $decodedData = $this->helper->decodeData($data);
+                
+                // Validate schema contains required fields
+                $validationResult = $this->validateSchemaFields($decodedData);
+                
+                if (!$validationResult['valid']) {
+                    $this->logger->warning('GraphQL Schema Reader: Schema validation failed, regenerating', [
+                        'errors' => $validationResult['errors']
+                    ]);
+                    // Regenerate schema on validation failure
+                    $data = $proceed();
+                    $this->helper->saveFileContent($filename, $this->helper->encodeData($data));
+                    $this->logger->info('GraphQL Schema Reader: Schema regenerated after validation failure');
+                    return $data;
+                }
+                
+                $this->logger->info('GraphQL Schema Reader: Schema loaded from cache successfully');
+                return $decodedData;
+            } catch (\Exception $e) {
+                $this->logger->error('GraphQL Schema Reader: Decode failure, regenerating schema', [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString()
+                ]);
+                // Regenerate schema on decode failure
+                $data = $proceed();
+                $this->helper->saveFileContent($filename, $this->helper->encodeData($data));
+                $this->logger->info('GraphQL Schema Reader: Schema regenerated after decode failure');
+                return $data;
+            }
         }
+    }
+
+    /**
+     * Validate that schema contains alternate_urls and canonical_url fields
+     *
+     * @param array $schemaData
+     * @return array ['valid' => bool, 'errors' => array]
+     */
+    protected function validateSchemaFields(array $schemaData): array
+    {
+        $errors = [];
+        $requiredFields = ['alternate_urls', 'canonical_url'];
+        $requiredTypes = ['ProductInterface', 'CategoryInterface', 'CmsPage'];
+        
+        // Check if schema data structure is valid
+        if (!isset($schemaData['types']) || !is_array($schemaData['types'])) {
+            $errors[] = 'Schema types structure is invalid';
+            return ['valid' => false, 'errors' => $errors];
+        }
+        
+        $types = $schemaData['types'];
+        $foundFields = [];
+        
+        // Check each required type
+        foreach ($requiredTypes as $typeName) {
+            if (!isset($types[$typeName])) {
+                $errors[] = sprintf('Required type %s not found in schema', $typeName);
+                continue;
+            }
+            
+            $type = $types[$typeName];
+            
+            // Check if type has fields
+            if (!isset($type['fields']) || !is_array($type['fields'])) {
+                $errors[] = sprintf('Type %s has no fields defined', $typeName);
+                continue;
+            }
+            
+            $fields = $type['fields'];
+            
+            // Check for required fields
+            foreach ($requiredFields as $fieldName) {
+                if (isset($fields[$fieldName])) {
+                    $foundFields[] = sprintf('%s.%s', $typeName, $fieldName);
+                } else {
+                    $errors[] = sprintf('Field %s not found in type %s', $fieldName, $typeName);
+                }
+            }
+        }
+        
+        if (!empty($errors)) {
+            return ['valid' => false, 'errors' => $errors];
+        }
+        
+        $this->logger->debug('GraphQL Schema Reader: Schema validation passed', [
+            'found_fields' => $foundFields
+        ]);
+        
+        return ['valid' => true, 'errors' => []];
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,6 +5,9 @@
 			<module name="Magento_Backend"/>
 			<module name="Magento_Framework"/>
             <module name="Magento_GraphQl"/>
+            <module name="Magento_CatalogGraphQl"/>
+            <module name="Magento_CmsGraphQl"/>
+            <module name="Magento_Store"/>
 		</sequence>
 	</module>
 </config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,54 @@
+# Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+# See COPYING.txt for license details.
+
+# Extend ProductInterface with alternate URLs and canonical URL
+type ProductInterface {
+    """
+    Alternate URLs for hreflang tags
+    """
+    alternate_urls: [AlternateUrl] @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\Product\\AlternateUrls")
+    
+    """
+    Canonical URL for the product
+    """
+    canonical_url: String @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\Product\\CanonicalUrl")
+}
+
+# Extend CategoryInterface with alternate URLs and canonical URL
+type CategoryInterface {
+    """
+    Alternate URLs for hreflang tags
+    """
+    alternate_urls: [AlternateUrl] @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\Category\\AlternateUrls")
+    
+    """
+    Canonical URL for the category
+    """
+    canonical_url: String @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\Category\\CanonicalUrl")
+}
+
+# Extend CmsPage with alternate URLs and canonical URL
+type CmsPage {
+    """
+    Alternate URLs for hreflang tags
+    """
+    alternate_urls: [AlternateUrl] @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\CmsPage\\AlternateUrls")
+    
+    """
+    Canonical URL for the CMS page
+    """
+    canonical_url: String @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\CmsPage\\CanonicalUrl")
+}
+
+# Alternate URL type for hreflang tags
+type AlternateUrl {
+    """
+    Language code (e.g., 'en-US', 'nl-NL')
+    """
+    hreflang: String!
+    
+    """
+    URL for the alternate language version
+    """
+    href: String!
+}


### PR DESCRIPTION
Add `hreflang` tags and canonical URLs to GraphQL API for multi-language SEO support across products, categories, and CMS pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-5dc37b5c-0b30-4e2b-bcc7-52220bdfaa8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5dc37b5c-0b30-4e2b-bcc7-52220bdfaa8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

