### PR TITLE
Add common fields to content block graphql

### DIFF
--- a/app/code/Experius/ContentBlockDynamicGraphQl/etc/schema.graphqls
+++ b/app/code/Experius/ContentBlockDynamicGraphQl/etc/schema.graphqls
@@ -1,0 +1,5 @@
+type ContentBlockDynamic {
+    identifier: String
+    link: String
+    is_active: Boolean
+}


### PR DESCRIPTION
Add `identifier`, `link`, and `is_active` fields to the `ContentBlockDynamic` GraphQL type to expose common frontend fields for dynamic menus and USPS integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-d55806fa-a8b1-454e-afa1-f2afdbd24fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d55806fa-a8b1-454e-afa1-f2afdbd24fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

