### PR TITLE
Integrate customer default address GraphQL mutation

### DIFF
--- a/CustomerAddressGraphQl/COPYING.txt
+++ b/CustomerAddressGraphQl/COPYING.txt
@@ -1,0 +1,6 @@
+Copyright © 2023-present Happy Horizon Utrecht Development & Technology B.V.
+
+This file included in HappyHorizon/CustomerAddressGraphQl is licensed under OSL 3.0
+
+http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+Please see LICENSE.txt for the full text of the OSL 3.0 license

--- a/CustomerAddressGraphQl/Model/Resolver/SetDefaultAddress.php
+++ b/CustomerAddressGraphQl/Model/Resolver/SetDefaultAddress.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace HappyHorizon\CustomerAddressGraphQl\Model\Resolver;
+
+use Magento\Customer\Api\AddressRepositoryInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthenticationException;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\ContextInterface;
+
+/**
+ * Resolver for setDefaultAddress mutation
+ */
+class SetDefaultAddress implements ResolverInterface
+{
+    /**
+     * @param AddressRepositoryInterface $addressRepository
+     * @param CustomerRepositoryInterface $customerRepository
+     */
+    public function __construct(
+        private readonly AddressRepositoryInterface $addressRepository,
+        private readonly CustomerRepositoryInterface $customerRepository
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        /** @var ContextInterface $context */
+        if (false === $context->getExtensionAttributes()->getIsCustomer()) {
+            throw new GraphQlAuthenticationException(__('The current customer isn\'t authorized.'));
+        }
+
+        $customerId = (int)$context->getUserId();
+        $addressId = (int)$args['addressId'];
+        $addressType = strtolower($args['addressType']);
+
+        try {
+            // Verify the address belongs to the customer
+            $address = $this->addressRepository->getById($addressId);
+            
+            if ((int)$address->getCustomerId() !== $customerId) {
+                throw new GraphQlAuthorizationException(
+                    __('The address with ID "%1" does not belong to the current customer.', $addressId)
+                );
+            }
+
+            // Get customer and update default address
+            $customer = $this->customerRepository->getById($customerId);
+
+            if ($addressType === 'shipping') {
+                $customer->setDefaultShipping($addressId);
+            } elseif ($addressType === 'billing') {
+                $customer->setDefaultBilling($addressId);
+            } else {
+                throw new GraphQlInputException(
+                    __('Invalid address type. Must be either "shipping" or "billing".')
+                );
+            }
+
+            $this->customerRepository->save($customer);
+
+            return [
+                'success' => true,
+                'message' => __('Default %1 address has been updated successfully.', $addressType)
+            ];
+        } catch (NoSuchEntityException $e) {
+            throw new GraphQlNoSuchEntityException(
+                __('The address with ID "%1" does not exist.', $addressId),
+                $e
+            );
+        } catch (LocalizedException $e) {
+            throw new GraphQlInputException(__($e->getMessage()), $e);
+        }
+    }
+}

--- a/CustomerAddressGraphQl/README.md
+++ b/CustomerAddressGraphQl/README.md
@@ -1,0 +1,64 @@
+# HappyHorizon CustomerAddressGraphQl Module
+
+This module provides GraphQL mutations for managing customer addresses in Magento 2.
+
+## Features
+
+- **setDefaultAddress mutation**: Allows authenticated customers to set their default shipping or billing address.
+
+## Installation
+
+1. Copy the module to `app/code/HappyHorizon/CustomerAddressGraphQl/`
+2. Run `bin/magento module:enable HappyHorizon_CustomerAddressGraphQl`
+3. Run `bin/magento setup:upgrade`
+4. Run `bin/magento cache:flush`
+
+## GraphQL Usage
+
+### setDefaultAddress Mutation
+
+Set a default shipping or billing address for the authenticated customer.
+
+**Mutation:**
+```graphql
+mutation {
+    setDefaultAddress(
+        addressId: 123
+        addressType: SHIPPING
+    ) {
+        success
+        message
+    }
+}
+```
+
+**Parameters:**
+- `addressId` (Int!, required): The ID of the address to set as default
+- `addressType` (AddressType!, required): Either `SHIPPING` or `BILLING`
+
+**Response:**
+- `success` (Boolean!): Indicates whether the operation was successful
+- `message` (String): Response message
+
+**Example Response:**
+```json
+{
+    "data": {
+        "setDefaultAddress": {
+            "success": true,
+            "message": "Default shipping address has been updated successfully."
+        }
+    }
+}
+```
+
+## Requirements
+
+- Magento 2.4.x or higher
+- PHP 8.0 or higher
+- Magento Customer module
+- Magento GraphQL module
+
+## License
+
+OSL-3.0

--- a/CustomerAddressGraphQl/composer.json
+++ b/CustomerAddressGraphQl/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "happyhorizon/module-customer-address-graphql",
+    "description": "GraphQL module for customer address management - setDefaultAddress mutation",
+    "type": "magento2-module",
+    "license": "OSL-3.0",
+    "authors": [
+        {
+            "name": "Happy Horizon Utrecht Development & Technology B.V.",
+            "email": "info@happyhorizon.com"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {
+        "php": "^8",
+        "magento/framework": "*",
+        "magento/module-customer": "*",
+        "magento/module-graph-ql": "*"
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "HappyHorizon\\CustomerAddressGraphQl\\": ""
+        }
+    }
+}

--- a/CustomerAddressGraphQl/etc/di.xml
+++ b/CustomerAddressGraphQl/etc/di.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- GraphQL resolvers are automatically discovered via schema.graphqls @resolver annotation -->
+</config>

--- a/CustomerAddressGraphQl/etc/module.xml
+++ b/CustomerAddressGraphQl/etc/module.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="HappyHorizon_CustomerAddressGraphQl">
+        <sequence>
+            <module name="Magento_Customer"/>
+            <module name="Magento_GraphQl"/>
+        </sequence>
+    </module>
+</config>

--- a/CustomerAddressGraphQl/etc/schema.graphqls
+++ b/CustomerAddressGraphQl/etc/schema.graphqls
@@ -1,0 +1,16 @@
+type Mutation {
+    setDefaultAddress(
+        addressId: Int!
+        addressType: AddressType!
+    ): SetDefaultAddressOutput @resolver(class: "HappyHorizon\\CustomerAddressGraphQl\\Model\\Resolver\\SetDefaultAddress") @doc(description: "Set default shipping or billing address for the authenticated customer")
+}
+
+enum AddressType {
+    SHIPPING @value(name: "shipping")
+    BILLING @value(name: "billing")
+}
+
+type SetDefaultAddressOutput {
+    success: Boolean! @doc(description: "Indicates whether the operation was successful")
+    message: String @doc(description: "Response message")
+}

--- a/CustomerAddressGraphQl/registration.php
+++ b/CustomerAddressGraphQl/registration.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Copyright © Happy Horizon Utrecht Development & Technology B.V. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'HappyHorizon_CustomerAddressGraphQl',
+    __DIR__
+);


### PR DESCRIPTION
Add `HappyHorizon_CustomerAddressGraphQl` module to introduce `setDefaultAddress` GraphQL mutation for managing customer default addresses.

---
<a href="https://cursor.com/background-agent?bcId=bc-22f88daa-7f08-4d1c-9100-bc14b10f4aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22f88daa-7f08-4d1c-9100-bc14b10f4aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

