### PR TITLE
Add backend support for dynamic menus and usps

### DIFF
--- a/Model/DataProvider/Block.php
+++ b/Model/DataProvider/Block.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\DataProvider;
+
+use Magento\Cms\Api\BlockRepositoryInterface;
+use Magento\Cms\Api\Data\BlockInterface;
+use Magento\Cms\Model\BlockFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Serialize\Serializer\Serialize;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Block
+{
+    /**
+     * @param BlockRepositoryInterface $blockRepository
+     * @param BlockFactory $blockFactory
+     * @param StoreManagerInterface $storeManager
+     * @param Json $jsonSerializer
+     * @param Serialize $serializeSerializer
+     */
+    public function __construct(
+        protected BlockRepositoryInterface $blockRepository,
+        protected BlockFactory $blockFactory,
+        protected StoreManagerInterface $storeManager,
+        protected Json $jsonSerializer,
+        protected Serialize $serializeSerializer
+    ) {
+    }
+
+    /**
+     * Get CMS block by identifier
+     *
+     * @param string $identifier
+     * @return BlockInterface|null
+     */
+    public function getBlockByIdentifier(string $identifier): ?BlockInterface
+    {
+        try {
+            // Try to get by ID if identifier is numeric
+            if (is_numeric($identifier)) {
+                return $this->blockRepository->getById((int)$identifier);
+            }
+            
+            // Load by identifier using block factory
+            $block = $this->blockFactory->create();
+            $storeId = (int)$this->storeManager->getStore()->getId();
+            $block->setStoreId($storeId);
+            $block->load($identifier, 'identifier');
+            
+            if ($block->getId()) {
+                return $this->blockRepository->getById($block->getId());
+            }
+            
+            return null;
+        } catch (NoSuchEntityException $e) {
+            return null;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Extract menu_items from CMS block attributes
+     *
+     * @param BlockInterface $block
+     * @return array
+     */
+    public function getMenuItems(BlockInterface $block): array
+    {
+        $menuItems = [];
+        
+        // Try to get menu_items from custom attributes or content
+        $attributes = $block->getData();
+        
+        // Check for menu_items attribute
+        if (isset($attributes['menu_items'])) {
+            $menuItemsData = $attributes['menu_items'];
+            $menuItems = $this->parseMenuItems($menuItemsData);
+        }
+        
+        // Also check content for JSON/serialized data
+        $content = $block->getContent();
+        if ($content) {
+            $parsedContent = $this->parseContentForMenuItems($content);
+            if (!empty($parsedContent)) {
+                $menuItems = array_merge($menuItems, $parsedContent);
+            }
+        }
+        
+        return $menuItems;
+    }
+
+    /**
+     * Extract usp_items from CMS block attributes
+     *
+     * @param BlockInterface $block
+     * @return array
+     */
+    public function getUspItems(BlockInterface $block): array
+    {
+        $uspItems = [];
+        
+        // Try to get usp_items from custom attributes or content
+        $attributes = $block->getData();
+        
+        // Check for usp_items attribute
+        if (isset($attributes['usp_items'])) {
+            $uspItemsData = $attributes['usp_items'];
+            $uspItems = $this->parseUspItems($uspItemsData);
+        }
+        
+        // Also check content for JSON/serialized data
+        $content = $block->getContent();
+        if ($content) {
+            $parsedContent = $this->parseContentForUspItems($content);
+            if (!empty($parsedContent)) {
+                $uspItems = array_merge($uspItems, $parsedContent);
+            }
+        }
+        
+        return $uspItems;
+    }
+
+    /**
+     * Parse menu items from various formats (JSON, serialized, array)
+     *
+     * @param mixed $data
+     * @return array
+     */
+    protected function parseMenuItems($data): array
+    {
+        if (empty($data)) {
+            return [];
+        }
+
+        // If already an array, return as is
+        if (is_array($data)) {
+            return $this->formatMenuItems($data);
+        }
+
+        // Try JSON decode
+        if (is_string($data)) {
+            // Try JSON first
+            $jsonData = $this->jsonSerializer->unserialize($data);
+            if (is_array($jsonData)) {
+                return $this->formatMenuItems($jsonData);
+            }
+
+            // Try PHP serialize
+            try {
+                $serializedData = $this->serializeSerializer->unserialize($data);
+                if (is_array($serializedData)) {
+                    return $this->formatMenuItems($serializedData);
+                }
+            } catch (\Exception $e) {
+                // Not serialized, continue
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Parse USP items from various formats (JSON, serialized, array)
+     *
+     * @param mixed $data
+     * @return array
+     */
+    protected function parseUspItems($data): array
+    {
+        if (empty($data)) {
+            return [];
+        }
+
+        // If already an array, return as is
+        if (is_array($data)) {
+            return $this->formatUspItems($data);
+        }
+
+        // Try JSON decode
+        if (is_string($data)) {
+            // Try JSON first
+            $jsonData = $this->jsonSerializer->unserialize($data);
+            if (is_array($jsonData)) {
+                return $this->formatUspItems($jsonData);
+            }
+
+            // Try PHP serialize
+            try {
+                $serializedData = $this->serializeSerializer->unserialize($data);
+                if (is_array($serializedData)) {
+                    return $this->formatUspItems($serializedData);
+                }
+            } catch (\Exception $e) {
+                // Not serialized, continue
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Parse content string for menu items (looks for JSON/serialized data)
+     *
+     * @param string $content
+     * @return array
+     */
+    protected function parseContentForMenuItems(string $content): array
+    {
+        // Look for menu_items in content (could be in data attributes, JSON, etc.)
+        // Try to extract JSON from content
+        if (preg_match('/menu_items["\']?\s*[:=]\s*(\[[^\]]+\]|\{[^}]+\})/i', $content, $matches)) {
+            $jsonData = $this->jsonSerializer->unserialize($matches[1]);
+            if (is_array($jsonData)) {
+                return $this->formatMenuItems($jsonData);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Parse content string for USP items (looks for JSON/serialized data)
+     *
+     * @param string $content
+     * @return array
+     */
+    protected function parseContentForUspItems(string $content): array
+    {
+        // Look for usp_items in content (could be in data attributes, JSON, etc.)
+        // Try to extract JSON from content
+        if (preg_match('/usp_items["\']?\s*[:=]\s*(\[[^\]]+\]|\{[^}]+\})/i', $content, $matches)) {
+            $jsonData = $this->jsonSerializer->unserialize($matches[1]);
+            if (is_array($jsonData)) {
+                return $this->formatUspItems($jsonData);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Format menu items array to ensure proper structure
+     *
+     * @param array $items
+     * @return array
+     */
+    protected function formatMenuItems(array $items): array
+    {
+        $formatted = [];
+        
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            
+            $formattedItem = [
+                'label' => $item['label'] ?? $item['title'] ?? '',
+                'url' => $item['url'] ?? $item['link'] ?? '',
+                'target' => $item['target'] ?? '_self',
+                'children' => []
+            ];
+            
+            // Handle nested children
+            if (isset($item['children']) && is_array($item['children'])) {
+                $formattedItem['children'] = $this->formatMenuItems($item['children']);
+            }
+            
+            $formatted[] = $formattedItem;
+        }
+        
+        return $formatted;
+    }
+
+    /**
+     * Format USP items array to ensure proper structure
+     *
+     * @param array $items
+     * @return array
+     */
+    protected function formatUspItems(array $items): array
+    {
+        $formatted = [];
+        
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            
+            $formattedItem = [
+                'label' => $item['label'] ?? $item['title'] ?? '',
+                'icon' => $item['icon'] ?? '',
+                'description' => $item['description'] ?? $item['text'] ?? ''
+            ];
+            
+            $formatted[] = $formattedItem;
+        }
+        
+        return $formatted;
+    }
+
+    /**
+     * Extract link/url from block attributes
+     *
+     * @param BlockInterface $block
+     * @return string
+     */
+    public function getLink(BlockInterface $block): string
+    {
+        $attributes = $block->getData();
+        return $attributes['link'] ?? $attributes['url'] ?? '';
+    }
+
+    /**
+     * Extract URL from block attributes
+     *
+     * @param BlockInterface $block
+     * @return string
+     */
+    public function getUrl(BlockInterface $block): string
+    {
+        $attributes = $block->getData();
+        return $attributes['url'] ?? $attributes['link'] ?? '';
+    }
+}

--- a/Model/Resolver/Footer.php
+++ b/Model/Resolver/Footer.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver;
+
+use HappyHorizon\PersistentGraphQlSchema\Model\DataProvider\Block as BlockDataProvider;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class Footer implements ResolverInterface
+{
+    /**
+     * @param BlockDataProvider $blockDataProvider
+     */
+    public function __construct(
+        protected BlockDataProvider $blockDataProvider
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($args['identifier']) || empty($args['identifier'])) {
+            return null;
+        }
+
+        $block = $this->blockDataProvider->getBlockByIdentifier($args['identifier']);
+        
+        if (!$block) {
+            return null;
+        }
+
+        return [
+            'identifier' => $block->getIdentifier(),
+            'title' => $block->getTitle(),
+            'content' => $block->getContent(),
+            'link' => $this->blockDataProvider->getLink($block),
+            'url' => $this->blockDataProvider->getUrl($block),
+            'menu_items' => $this->blockDataProvider->getMenuItems($block),
+            'usp_items' => $this->blockDataProvider->getUspItems($block)
+        ];
+    }
+}

--- a/Model/Resolver/MegaMenu.php
+++ b/Model/Resolver/MegaMenu.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver;
+
+use HappyHorizon\PersistentGraphQlSchema\Model\DataProvider\Block as BlockDataProvider;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class MegaMenu implements ResolverInterface
+{
+    /**
+     * @param BlockDataProvider $blockDataProvider
+     */
+    public function __construct(
+        protected BlockDataProvider $blockDataProvider
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($args['identifier']) || empty($args['identifier'])) {
+            return null;
+        }
+
+        $block = $this->blockDataProvider->getBlockByIdentifier($args['identifier']);
+        
+        if (!$block) {
+            return null;
+        }
+
+        return [
+            'identifier' => $block->getIdentifier(),
+            'title' => $block->getTitle(),
+            'content' => $block->getContent(),
+            'link' => $this->blockDataProvider->getLink($block),
+            'url' => $this->blockDataProvider->getUrl($block),
+            'menu_items' => $this->blockDataProvider->getMenuItems($block),
+            'usp_items' => $this->blockDataProvider->getUspItems($block)
+        ];
+    }
+}

--- a/Model/Resolver/MenuItems.php
+++ b/Model/Resolver/MenuItems.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class MenuItems implements ResolverInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        // This resolver handles the menu_items field on ContentBlockDynamic
+        if (isset($value['menu_items']) && is_array($value['menu_items'])) {
+            return $value['menu_items'];
+        }
+        
+        // This resolver also handles fields on MenuItems type (label, url, target, children)
+        if (isset($value['label']) || isset($value['url']) || isset($value['target']) || isset($value['children'])) {
+            return $value[$field->getName()] ?? null;
+        }
+        
+        return [];
+    }
+}

--- a/Model/Resolver/Topbar.php
+++ b/Model/Resolver/Topbar.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver;
+
+use HappyHorizon\PersistentGraphQlSchema\Model\DataProvider\Block as BlockDataProvider;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class Topbar implements ResolverInterface
+{
+    /**
+     * @param BlockDataProvider $blockDataProvider
+     */
+    public function __construct(
+        protected BlockDataProvider $blockDataProvider
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($args['identifier']) || empty($args['identifier'])) {
+            return null;
+        }
+
+        $block = $this->blockDataProvider->getBlockByIdentifier($args['identifier']);
+        
+        if (!$block) {
+            return null;
+        }
+
+        return [
+            'identifier' => $block->getIdentifier(),
+            'title' => $block->getTitle(),
+            'content' => $block->getContent(),
+            'link' => $this->blockDataProvider->getLink($block),
+            'url' => $this->blockDataProvider->getUrl($block),
+            'menu_items' => $this->blockDataProvider->getMenuItems($block),
+            'usp_items' => $this->blockDataProvider->getUspItems($block)
+        ];
+    }
+}

--- a/Model/Resolver/UspItems.php
+++ b/Model/Resolver/UspItems.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class UspItems implements ResolverInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        // This resolver handles the usp_items field on ContentBlockDynamic
+        if (isset($value['usp_items']) && is_array($value['usp_items'])) {
+            return $value['usp_items'];
+        }
+        
+        // This resolver also handles fields on UspItems type (label, icon, description)
+        if (isset($value['label']) || isset($value['icon']) || isset($value['description'])) {
+            return $value[$field->getName()] ?? null;
+        }
+        
+        return [];
+    }
+}

--- a/Model/Resolver/Usps.php
+++ b/Model/Resolver/Usps.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace HappyHorizon\PersistentGraphQlSchema\Model\Resolver;
+
+use HappyHorizon\PersistentGraphQlSchema\Model\DataProvider\Block as BlockDataProvider;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class Usps implements ResolverInterface
+{
+    /**
+     * @param BlockDataProvider $blockDataProvider
+     */
+    public function __construct(
+        protected BlockDataProvider $blockDataProvider
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($args['identifier']) || empty($args['identifier'])) {
+            return null;
+        }
+
+        $block = $this->blockDataProvider->getBlockByIdentifier($args['identifier']);
+        
+        if (!$block) {
+            return null;
+        }
+
+        return [
+            'identifier' => $block->getIdentifier(),
+            'title' => $block->getTitle(),
+            'content' => $block->getContent(),
+            'link' => $this->blockDataProvider->getLink($block),
+            'url' => $this->blockDataProvider->getUrl($block),
+            'menu_items' => $this->blockDataProvider->getMenuItems($block),
+            'usp_items' => $this->blockDataProvider->getUspItems($block)
+        ];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -6,4 +6,29 @@
                 type="HappyHorizon\PersistentGraphQlSchema\Plugin\Graphql\Magento\Framework\GraphQlSchemaStitching\Common\Reader"
                 sortOrder="0"/>
     </type>
+    
+    <!-- GraphQL Resolvers -->
+    <type name="Magento\Framework\GraphQl\Query\Resolver\Query">
+        <arguments>
+            <argument name="resolvers" xsi:type="array">
+                <item name="getMegaMenu" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\MegaMenu</item>
+                <item name="getTopbar" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\Topbar</item>
+                <item name="getUsps" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\Usps</item>
+                <item name="getFooter" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\Footer</item>
+            </argument>
+        </arguments>
+    </type>
+    
+    <type name="Magento\Framework\GraphQl\Query\Resolver\Type">
+        <arguments>
+            <argument name="resolvers" xsi:type="array">
+                <item name="ContentBlockDynamic" xsi:type="array">
+                    <item name="menu_items" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\MenuItems</item>
+                    <item name="usp_items" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\UspItems</item>
+                </item>
+                <item name="MenuItems" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\MenuItems</item>
+                <item name="UspItems" xsi:type="string">HappyHorizon\PersistentGraphQlSchema\Model\Resolver\UspItems</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,6 +5,7 @@
 			<module name="Magento_Backend"/>
 			<module name="Magento_Framework"/>
             <module name="Magento_GraphQl"/>
+			<module name="Magento_Cms"/>
 		</sequence>
 	</module>
 </config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,29 @@
+type Query {
+    getMegaMenu(identifier: String!): ContentBlockDynamic @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\MegaMenu")
+    getTopbar(identifier: String!): ContentBlockDynamic @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\Topbar")
+    getUsps(identifier: String!): ContentBlockDynamic @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\Usps")
+    getFooter(identifier: String!): ContentBlockDynamic @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\Footer")
+}
+
+type ContentBlockDynamic {
+    identifier: String
+    title: String
+    content: String
+    link: String
+    url: String
+    menu_items: [MenuItems] @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\MenuItems")
+    usp_items: [UspItems] @resolver(class: "HappyHorizon\\PersistentGraphQlSchema\\Model\\Resolver\\UspItems")
+}
+
+type MenuItems {
+    label: String
+    url: String
+    target: String
+    children: [MenuItems]
+}
+
+type UspItems {
+    label: String
+    icon: String
+    description: String
+}


### PR DESCRIPTION
Adds GraphQL backend support for dynamic menus and USPS integration by exposing CMS block data.

---
<a href="https://cursor.com/background-agent?bcId=bc-700c7347-feb6-4bc3-b0ca-e6a3a90b8ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-700c7347-feb6-4bc3-b0ca-e6a3a90b8ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

